### PR TITLE
Check config format for validity and then dump to secret as is

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -155,10 +155,12 @@ class APSConnectUtil:
         """ Install connector-backend in the k8s cluster"""
 
         try:
-            config_data = yaml.load(open(config_file))
             print("Loading config file: {}".format(config_file))
+            with open(config_file) as f:
+                config_data = f.read()
+            yaml.load(config_data)  # we only need to check if this is valid YAML or JSON
         except yaml.YAMLError as e:
-            print('Config file should be valid JSON or YAML, error: {}'.format(e))
+            print("Config file should be valid JSON or YAML structure, error: {}".format(e))
         except Exception as e:
             print("Unable to read config file, error: {}".format(e))
             sys.exit(1)
@@ -560,7 +562,7 @@ def _create_secret(name, data, api, namespace='default', force=False):
     secret = {
         'apiVersion': 'v1',
         'data': {
-            'config': base64.b64encode(json.dumps(data).encode('utf-8')).decode(),
+            'config': base64.b64encode(data.encode('utf-8')).decode(),
         },
         'kind': 'Secret',
         'metadata': {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.6.8',
+    version='1.6.9',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Seems to be working properly:

```bash
(cli) mbelov-laptop [apsconnectcli] (yaml-support) $ python apsconnect.py install-backend --name mbelov-tst-j14-v1 --image ingrammicrocloud/fallball-connector --config-file ~/Desktop/conf --healthcheck-path / --root-path /v1
Loading config file: /home/mbelov/Desktop/conf
Connected to cluster - https://x.x.x.x
Create config [ok]
Create deployment [ok]
Create service [ok]
Checking service availability
....
Expose service [ok]
Connector backend - http://y.y.y.y/v1
[Success]

(cli) mbelov-laptop [apsconnectcli] (yaml-support) $ kubectl get secret mbelov-tst-j14-v1 -o yaml | grep config | awk '{print $2}' | base64 -d
debug: true
devices_resource: DEVICES
diskspace_resource: DISKSPACE
fallball_service_authorization_token: 2fcf40ee1f6c18ab01d90385a2e911163e3b03ad
fallball_service_url: 'https://service-dot-mydevball.appspot.com/v1/'
oauth_key: mbelov-tst-j14-v1-3d50b006ca4048
oauth_secret: fdadc95617e040cea757990d822bd152
```