### PR TITLE
Unite root path and health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Config saved [/Users/allexx/.aps_config]
 
 ```
 apsconnect install-backend --name NAME --image IMAGE --config-file CONFIG_FILE \
-                          [--healthcheck-path HEALTHCHECK_PATH] [--root-path ROOT_PATH] \
-                          [--namespace NAMESPACE] [--replicas REPLICAS] [--force FORCE]
+                           [--root-path ROOT_PATH] [--namespace NAMESPACE] \
+                           [--replicas REPLICAS] [--force FORCE]
 ```
-
+__Note__: `--healthcheck-path` is deprecated as it should be the same value as `--root-path`
 ```
 ⇒  apsconnect install-backend connector_name image config_file
 Loading config file: /Users/allexx/config

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Config saved [/Users/allexx/.aps_config]
 
 ```
 apsconnect install-backend --name NAME --image IMAGE --config-file CONFIG_FILE --hostname HOST \
-                          [--root-path ROOT_PATH] [--namespace NAMESPACE] [--replicas REPLICAS] \
-                          [--force FORCE]
+                          [--healthcheck-path HEALTHCHECK_PATH] [--root-path ROOT_PATH] \
+                          [--namespace NAMESPACE] [--replicas REPLICAS] [--force FORCE]
 ```
-__Note__: `--healthcheck-path` is deprecated as it should be the same value as `--root-path`
+
 ```
 ⇒  apsconnect install-backend connector_name image hostname config_file
 Loading config file: /Users/allexx/config_file

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -149,7 +149,6 @@ class APSConnectUtil:
                                  indent=4))
             print("Config saved [{}]".format(CFG_FILE_PATH))
 
-
     def check_backend(self):
         """ Validate k8s components and get useful information"""
         api_client = _get_k8s_api_client()

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -149,9 +149,8 @@ class APSConnectUtil:
                                  indent=4))
             print("Config saved [{}]".format(CFG_FILE_PATH))
 
-    def install_backend(self, name, image, config_file, healthcheck_path='/',
-                        root_path='/', namespace='default', replicas=2,
-                        force=False):
+    def install_backend(self, name, image, config_file, root_path='/', namespace='default',
+                        replicas=2, force=False):
         """ Install connector-backend in the k8s cluster"""
 
         try:
@@ -186,7 +185,7 @@ class APSConnectUtil:
             sys.exit(1)
 
         try:
-            _create_deployment(name, image, ext_v1, healthcheck_path, replicas,
+            _create_deployment(name, image, ext_v1, root_path, replicas,
                                namespace, force, core_api=core_v1)
             print("Create deployment [ok]")
         except Exception as e:
@@ -593,7 +592,7 @@ def _delete_secret(name, api, namespace):
             raise
 
 
-def _create_deployment(name, image, api, healthcheck_path='/', replicas=2,
+def _create_deployment(name, image, api, root_path='/', replicas=2,
                        namespace='default', force=False, core_api=None):
     template = {
         'apiVersion': 'extensions/v1beta1',
@@ -622,13 +621,13 @@ def _create_deployment(name, image, api, healthcheck_path='/', replicas=2,
                             ],
                             'livenessProbe': {
                                 'httpGet': {
-                                    'path': healthcheck_path,
+                                    'path': root_path,
                                     'port': 80,
                                 },
                             },
                             'readinessProbe': {
                                 'httpGet': {
-                                    'path': healthcheck_path,
+                                    'path': root_path,
                                     'port': 80,
                                 },
                             },

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -421,7 +421,6 @@ class APSConnectUtil:
 
             # Create parameters resource types
             parameters = _get_parameters(tenant_schema_path)
-            parameters_ids = []
 
             for parameter in parameters:
                 payload = {
@@ -448,7 +447,6 @@ class APSConnectUtil:
 
                 resource_types_ids.append(response['result']['resource_type_id'])
                 limited_resources[response['result']['resource_type_id']] = 0
-
 
             print("Resource types creation [ok]")
 
@@ -771,6 +769,7 @@ def _polling_service_access(name, api, namespace, timeout=120):
 
         time.sleep(10)
 
+
 def _get_resources(tenant_schema_path, type='Counter'):
     resource_type = 'http://aps-standard.org/types/core/resource/1.0#{}'.format(type)
     tenant_properties = _get_properties(tenant_schema_path)
@@ -781,11 +780,14 @@ def _get_resources(tenant_schema_path, type='Counter'):
 
     return resources
 
+
 def _get_counters(tenant_schema_path):
     return _get_resources(tenant_schema_path, 'Counter')
 
+
 def _get_parameters(tenant_schema_path):
     return _get_resources(tenant_schema_path, 'Limit')
+
 
 def _get_properties(schema_path):
     with open(schema_path) as file:

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -175,7 +175,7 @@ class APSConnectUtil:
         print("apsconnect-cli v.{} built with love."
               .format(pkg_resources.get_distribution('apsconnectcli').version))
 
-    def install_backend(self, name, image, config_file, hostname, healthcheck_path=False,
+    def install_backend(self, name, image, config_file, hostname, healthcheck_path=None,
                         root_path='/', namespace='default', replicas=2,
                         force=False):
         """ Install connector-backend in the k8s cluster"""

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.6.10',
+    version='1.6.11',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.0',
+    version='1.7.1',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
As root path should be the same as health check, `--healthcheck-path` option is deleted