### PR TITLE
Sub-command 'info' was added.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.2',
+    version='1.7.3',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Sub-command 'info' was added. It reads host and user from configs of OA Hub and Kubernetes cluster and then prints to standard output. For example:
```
OA Hub:
	host: 10.31.225.239:8440
	user: admin
Kube cluster:
	host: https://130.211.72.0
	user: admin
```

In case of config absence the phrase 'Not initiated' will be printed instead:

```
OA Hub:
	host: 10.31.225.239:8440
        user: admin
Kube cluster:
	Not initiated
```

In case of config corruption the output will look like this:
```
OA Hub:
	Not initiated
Kube cluster:
	Config file is corrupted: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 5, column 5:
        	server: 'https://130.211.72.0'}
        ^;

``` 