### PR TITLE
Add more facts about install-frontend parameters in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Connector backend - https://xxx
 ```
 apsconnect install-frontend --source SOURCE --oauth-key OAUTH_KEY --oauth-secret OAUTH_SECRET \
 				            --backend-url BACKEND_URL [--settings-file SETTINGS_FILE] \
-				            [--network NETWORK]
+				            [--network = public ] [--use-proxy] [--hub-id = None]
 ```
 ```
 ⇒  apsconnect install-frontend package.aps.zip application-3-v1-687fd3e99eb 639a0c2bf3ab461aaf74a5c622d1fa34 --backend-url http://127.197.49.26/
@@ -85,6 +85,7 @@ Resource types creation [ok]
 Service template "connector" created with id=16 [ok]
 ```
 
+_Note that `--network proxy` enables support of outbound proxy. [More details](https://doc.apsstandard.org/7.1/concepts/backend/connectors/proxy/#setting-external-application-instance)_
 ## Misc
 
 #### Check utility version
@@ -103,7 +104,7 @@ OAuh key: test-c77e25b1d6974a87b2ff7f58092d6007
 Secret:   14089074ca9a4abd80ba45a19baae693
 ```
 
-_Note that --source gets http(s):// or filepath argument._
+_Note that `--source` gets http(s):// or filepath argument._
 
 #### Validate the k8s cluster and grab some useful data
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Connector backend - https://xxx
 ```
 apsconnect install-frontend --source SOURCE --oauth-key OAUTH_KEY --oauth-secret OAUTH_SECRET \
 				            --backend-url BACKEND_URL [--settings-file SETTINGS_FILE] \
-				            [--network = public ] [--use-proxy] [--hub-id = None]
+				            [--network = public ] [--hub-id = None]
 ```
 ```
 ⇒  apsconnect install-frontend package.aps.zip application-3-v1-687fd3e99eb 639a0c2bf3ab461aaf74a5c622d1fa34 --backend-url http://127.197.49.26/

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.3',
+    version='1.7.4',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Sub-command `install-frontend` doc improvement
---

By default we use public `--network` type  

Possible values for `--network` parameter:
- public
- proxy

[More details](https://doc.apsstandard.org/7.1/concepts/backend/connectors/proxy/#setting-external-application-instance)