### PR TITLE
Use OA core resource instead of uuid generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Connector backend - https://xxx
 ```
 apsconnect install-frontend --source SOURCE --oauth-key OAUTH_KEY --oauth-secret OAUTH_SECRET \
 				            --backend-url BACKEND_URL [--settings-file SETTINGS_FILE] \
-				            [--network = public ] [--hub-id = None]
+				            [--network = public ]
 ```
 ```
 ⇒  apsconnect install-frontend package.aps.zip application-3-v1-687fd3e99eb 639a0c2bf3ab461aaf74a5c622d1fa34 --backend-url http://127.197.49.26/

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -267,6 +267,7 @@ class APSConnectUtil:
             with zipfile.ZipFile(package_path, 'r') as zip_ref:
                 meta_path = zip_ref.extract('APP-META.xml', path=tdir)
                 tenant_schema_path = zip_ref.extract('schemas/tenant.schema', tdir)
+                app_schema_path = zip_ref.extract('schemas/app.schema', tdir)
 
                 try:
                     zip_ref.extract('schemas/user.schema', tdir)

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -267,7 +267,6 @@ class APSConnectUtil:
             with zipfile.ZipFile(package_path, 'r') as zip_ref:
                 meta_path = zip_ref.extract('APP-META.xml', path=tdir)
                 tenant_schema_path = zip_ref.extract('schemas/tenant.schema', tdir)
-                app_schema_path = zip_ref.extract('schemas/app.schema', tdir)
 
                 try:
                     zip_ref.extract('schemas/user.schema', tdir)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.4',
+    version='1.7.5',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Currently, we use generated id for HubID parameter while endpoint deployment. The new behaviour is the following:
1. Get id of the resource implementing `http://parallels.com/aps/types/pa/poa/1.0 type`
1. Update payload with this id as `HubId`
1. Deploy endpoint with such parameter