### PR TITLE
Add logging to utility

### DIFF
--- a/apsconnectcli/action_logger.py
+++ b/apsconnectcli/action_logger.py
@@ -1,0 +1,16 @@
+class Logger(object):
+    def __init__(self, log_file, stream=None):
+        self.terminal = stream
+        self.log_file = open(log_file, "a")
+
+    def write(self, message):
+        if self.terminal:
+            self.terminal.write(message)
+
+        self.log_file.write(message)
+
+    def log(self, message):
+        self.log_file.write(message)
+
+    def flush(self):
+        self.log_file.flush()

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -22,6 +22,8 @@ from requests import request, get
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
+from apsconnectcli.action_logger import Logger
+
 if sys.version_info >= (3,):
     import tempfile
     import xmlrpc.client as xmlrpclib
@@ -30,6 +32,19 @@ else:
     import xmlrpclib
     import tempfile
     from backports.tempfile import TemporaryDirectory
+
+
+home = os.path.expanduser("~")
+
+log_dir = os.path.join(home, ".apsconnect")
+
+if not os.path.exists(log_dir):
+    os.makedirs(log_dir)
+
+log_file = os.path.join(log_dir, "apsconnect.log")
+
+sys.stdout = Logger(log_file, sys.stdout)
+sys.stderr = Logger(log_file, sys.stderr)
 
 warnings.filterwarnings('ignore')
 
@@ -1006,6 +1021,8 @@ def _get_hub_info():
 
 def main():
     try:
+        log_entry = ("=============================\n{}\n".format(" ".join(sys.argv)))
+        Logger(log_file).log(log_entry)
         fire.Fire(APSConnectUtil, name='apsconnect')
     except Exception as e:
         print("Error: {}".format(e))

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -34,21 +34,19 @@ else:
     from backports.tempfile import TemporaryDirectory
 
 
-home = os.path.expanduser("~")
+LOG_DIR = os.path.expanduser('~/.apsconnect')
 
-log_dir = os.path.join(home, ".apsconnect")
+if not os.path.exists(LOG_DIR):
+    os.makedirs(LOG_DIR)
 
-if not os.path.exists(log_dir):
-    os.makedirs(log_dir)
+LOG_FILE = os.path.join(LOG_DIR, "apsconnect.log")
 
-log_file = os.path.join(log_dir, "apsconnect.log")
-
-sys.stdout = Logger(log_file, sys.stdout)
-sys.stderr = Logger(log_file, sys.stderr)
+sys.stdout = Logger(LOG_FILE, sys.stdout)
+sys.stderr = Logger(LOG_FILE, sys.stderr)
 
 warnings.filterwarnings('ignore')
 
-CFG_FILE_PATH = os.path.expanduser('~/.aps_config')
+CFG_FILE_PATH = os.path.expanduser('~/.apsconnect/.aps_config')
 KUBE_DIR_PATH = os.path.expanduser('~/.kube')
 KUBE_FILE_PATH = '{}/config'.format(KUBE_DIR_PATH)
 RPC_CONNECT_PARAMS = ('host', 'user', 'password', 'ssl', 'port')
@@ -1022,7 +1020,7 @@ def _get_hub_info():
 def main():
     try:
         log_entry = ("=============================\n{}\n".format(" ".join(sys.argv)))
-        Logger(log_file).log(log_entry)
+        Logger(LOG_FILE).log(log_entry)
         fire.Fire(APSConnectUtil, name='apsconnect')
     except Exception as e:
         print("Error: {}".format(e))

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.9',
+    version='1.7.10',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Both stdout and stderr output will be written to a `~/.apsconnect/apsconnect.log`:
```
=============================
apsconnectcli/apsconnect info
OA Hub:
        host: provider.tld:8440
        user: <user>
Kube cluster:
        host: https://<ip>
        user: <user>
=============================
apsconnectcli/apsconnect install-frontend --wrong-option
Fire trace:
1. Initial component
2. Instantiated class "APSConnectUtil" (/apsconnectcli/apsconnect.py:96)
3. Accessed property "install-frontend" (build/bdist.macosx-10.6-intel/egg/apsconnectcli/apsconnect.py:270)
4. ('The function received no value for the required argument:', 'backend_url')

Type:        instancemethod
String form: <bound method APSConnectUtil.install_frontend of <apsconnectcli.apsconnect.APSConnectUtil instance at 0x105a47c20>>
File:        ~/apsconnect-cli/build/bdist.macosx-10.6-intel/egg/apsconnectcli/apsconnect.py
Line:        270
Docstring:   Install connector-frontend in Odin Automation Hub, --source can be http(s):// or
filepath

Usage:       apsconnect install-frontend SOURCE OAUTH_KEY OAUTH_SECRET BACKEND_URL [SETTINGS_FILE] [NETWORK] [HUB_ID]
             apsconnect install-frontend --source SOURCE --oauth-key OAUTH_KEY --oauth-secret OAUTH_SECRET --backend-url BACKEND_URL [--settings-file SETTINGS_FILE] [--network NETWORK] [--hub-id HUB_ID]
=============================
```