### PR TITLE
Support new oa versions

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import json
 import os
+import re
 import sys
 import time
 import copy
@@ -598,8 +599,16 @@ def _get_hub_version(hub):
 
 
 def _assert_hub_version(hub_version):
-    if not hub_version.startswith('oa-7.1-'):
-        print("Hub 7.1 version needed, got {}".format(hub_version))
+    supported_version = False
+
+    match = re.match(r'^oa-(?P<major>\d)\.(?P<minor>\d)-', hub_version)
+    if match:
+        major = int(match.groupdict()['major'])
+        minor = int(match.groupdict()['minor'])
+        supported_version = (major == 7 and minor > 0) or major > 7
+
+    if not supported_version:
+        print("Hub 7.1 version or above needed, got {}".format(hub_version))
         sys.exit(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Ingram Micro',
-    version='1.7.11',
+    version='1.7.12',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Before: 
```bash
$ apsconnect init-hub n.mbelov.ap.int.zone
APSConnect-cli v.1.7.11
Connectivity with Hub RPC API [ok]
Hub 7.1 version needed, got oa-7.3-1072
```

After:
```bash
$ apsconnect init-hub n.mbelov.ap.int.zone
APSConnect-cli v.1.7.11
Connectivity with Hub RPC API [ok]
Hub version oa-7.3-1072
Connectivity with Hub APS API [ok]
Config saved [/Users/mbelov/.apsconnect/.aps_config]
```