### PR TITLE
Fix unicode for init-hub command on python 2.7

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -607,7 +607,7 @@ def _get_aps_url(aps_host, aps_port, use_tls_aps):
 def _get_hub_version(hub):
     r = hub.statistics.getStatisticsReport(reports=[{'name': 'report-for-cep', 'value': ''}])
     _osaapi_raise_for_status(r)
-    tree = xml_et.fromstring(r['result'][0]['value'])
+    tree = xml_et.fromstring(r['result'][0]['value'].encode('utf-8'))
     return tree.find('ClientVersion').text
 
 


### PR DESCRIPTION
![fix-xml-unicode](https://user-images.githubusercontent.com/3339046/34777948-e9cba246-f62c-11e7-87dc-35f09dcfbdb7.png)
xml_et.fromstring() will not work with unicode strings on Python 2.7, see here:
https://bugs.python.org/issue11033#msg127740

Encoded strings work both with 2.x and 3.x.