### PR TITLE
Fix issue with info command

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -112,13 +112,9 @@ class APSConnectUtil:
         Hub().aps_devel_mode(disable)
 
     def info(self):
-        """ Show current state of apsconnect-cli binding with Kubernetes cluster and OA Hub"""
-
-        oa_hub_check = ("OA Hub:", lambda: os.path.exists(CFG_FILE_PATH), Hub.info())
-
-        for (item_name, check_config, get_info) in [oa_hub_check]:
-            print(item_name)
-            print(_check_binding(check_config, get_info))
+        """ Show current state of apsconnect-cli binding with OA Hub"""
+        print("OA Hub:")
+        print(_check_binding(lambda: os.path.exists(CFG_FILE_PATH),  _get_hub_info))
 
     def hub_token(self):
         hub = Hub()
@@ -156,6 +152,18 @@ def _check_binding(check_config, get_config_info):
     else:
         host, user = info
         return state_is_ready.format(host, user)
+
+
+def _get_hub_info():
+    if not os.path.exists(CFG_FILE_PATH):
+        return NULL_CFG_INFO
+
+    with open(CFG_FILE_PATH) as f:
+        hub_cfg = json.load(f)
+
+    host = "{}:{}".format(hub_cfg['host'], hub_cfg['port'])
+    user = hub_cfg['user']
+    return (host, user)
 
 
 def bin_version():

--- a/apsconnectcli/hub.py
+++ b/apsconnectcli/hub.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import json
-import os
 import re
 import sys
 import uuid
@@ -11,7 +10,7 @@ from xml.etree import ElementTree as xml_et
 import osaapi
 import requests
 
-from apsconnectcli.config import get_config, CFG_FILE_PATH, NULL_CFG_INFO
+from apsconnectcli.config import get_config, CFG_FILE_PATH
 
 RPC_CONNECT_PARAMS = ('host', 'user', 'password', 'ssl', 'port')
 APS_CONNECT_PARAMS = ('aps_host', 'aps_port', 'use_tls_aps')
@@ -117,18 +116,6 @@ class Hub(object):
             sys.exit(1)
         else:
             return data[0]['aps']['id'] if data else None
-
-    @staticmethod
-    def info():
-        if not os.path.exists(CFG_FILE_PATH):
-            return NULL_CFG_INFO
-
-        with open(CFG_FILE_PATH) as f:
-            hub_cfg = json.load(f)
-
-        host = '{}:{}'.format(hub_cfg['host'], hub_cfg['port'])
-        user = hub_cfg['user']
-        return host, user
 
     def get_admin_token(self):
         return Hub._get_user_token(self.osaapi, 1)


### PR DESCRIPTION
Currently, it is not possible to run apsconnect info:
```
Config file is corrupted: 'tuple' object is not callable
```
This PR delivers a fix for it