### PR TITLE
More Ops Friendly connect-cli

### DIFF
--- a/apsconnectcli/hub.py
+++ b/apsconnectcli/hub.py
@@ -193,7 +193,7 @@ class Hub(object):
         core_resource_types_payload = [
             {
                 'resclass_name': 'rc.saas.service.link',
-                'name': package.connector_name,
+                'name': '{} app instance'.format(package.connector_name),
                 'act_params': [
                     {
                         'var_name': 'app_id',
@@ -235,9 +235,10 @@ class Hub(object):
     def _create_counter_rts(self, package, app_id):
         rt_ids = {}
         for counter, schema in package.counters.items():
+            oa_unit_type = Hub._get_resclass_name(schema['unit'])
             payload = {
-                'resclass_name': Hub._get_resclass_name(schema['unit']),
-                'name': '{} {}'.format(package.connector_name, counter),
+                'resclass_name': oa_unit_type,
+                'name': '{}'.format(schema.get('title')),
                 'act_params': [
                     {
                         'var_name': 'app_id',
@@ -256,7 +257,10 @@ class Hub(object):
 
             response = self.osaapi.addResourceType(**payload)
             osaapi_raise_for_status(response)
-            rt_ids[response['result']['resource_type_id']] = -1
+            if oa_unit_type == "rc.saas.resource.unith" or oa_unit_type == "rc.saas.resource.mhzh":
+                rt_ids[response['result']['resource_type_id']] = -1
+            else:
+                rt_ids[response['result']['resource_type_id']] = 0
 
         return rt_ids
 

--- a/apsconnectcli/package.py
+++ b/apsconnectcli/package.py
@@ -117,8 +117,7 @@ class Package(object):
         self.version = tree.find('{}version'.format(ns)).text
         self.release = tree.find('{}release'.format(ns)).text
 
-        url_path = urlparse(self.connector_id).path
-        self.connector_name = os.path.split(url_path)[-1]
+        self.connector_name = tree.find('{}name'.format(ns)).text
 
         if self.instance_only:
             return

--- a/apsconnectcli/package.py
+++ b/apsconnectcli/package.py
@@ -3,7 +3,6 @@ import os
 import sys
 import zipfile
 from xml.etree import ElementTree as xml_et
-from future.moves.urllib.parse import urlparse
 
 from shutil import copyfile
 

--- a/tests/test_apsconnect_internals.py
+++ b/tests/test_apsconnect_internals.py
@@ -110,7 +110,7 @@ class TestHelpers(TestCase):
 
     def test_main_prints_version(self):
         with patch('apsconnectcli.apsconnect.fire'), \
-             patch('apsconnectcli.apsconnect.get_version') as get_version_mock, \
+                patch('apsconnectcli.apsconnect.get_version') as get_version_mock, \
                 patch(_BUILTINS_PRINT) as print_mock:
 
             get_version_mock.return_value = '100.500'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ class GetCfgTest(TestCase):
 
     def test_file_unreadable(self):
         with patch(_BUILTINS_OPEN), \
-             patch(_BUILTINS_PRINT) as print_mock, \
+                patch(_BUILTINS_PRINT) as print_mock, \
                 patch('apsconnectcli.config.json') as json_mock, \
                 patch('apsconnectcli.config.sys') as sys_mock:
             json_mock.load.side_effect = ValueError()
@@ -62,7 +62,7 @@ class GetCfgTest(TestCase):
 
     def test_unexpected_error(self):
         with patch(_BUILTINS_OPEN), \
-             patch(_BUILTINS_PRINT) as print_mock, \
+                patch(_BUILTINS_PRINT) as print_mock, \
                 patch('apsconnectcli.config.json') as json_mock, \
                 patch('apsconnectcli.config.sys') as sys_mock:
             json_mock.load.side_effect = Exception("All is lost")
@@ -75,7 +75,7 @@ class GetCfgTest(TestCase):
 
     def test_ok(self):
         with patch(_BUILTINS_OPEN), \
-             patch(_BUILTINS_PRINT) as print_mock, \
+                patch(_BUILTINS_PRINT) as print_mock, \
                 patch('apsconnectcli.config.json') as json_mock, \
                 patch('apsconnectcli.config.sys') as sys_mock:
             json_mock.load.return_value = 'Config data'


### PR DESCRIPTION
connect-cli tool has been modified to:

- When new Service template is created: Use product name instead of product ID
- Create OSA Resource types using title defined on tenant schema
- Set limits on ST depending on type of resource:
   - Unlimited for PPU
   - 0 for Reservation base